### PR TITLE
Fix 'Session' object has no attribute 'pid' error when spawning apps

### DIFF
--- a/frooky/frida_runner.py
+++ b/frooky/frida_runner.py
@@ -46,6 +46,7 @@ class FrookyRunner:
         self.session: Optional[frida.core.Session] = None
         self.script: Optional[frida.core.Script] = None
         self.device: Optional[frida.core.Device] = None
+        self.spawned_pid: Optional[int] = None
         self.event_count: int = 0
         self.last_event: str = "Waiting for events..."
         self.total_hooks: Optional[int] = None
@@ -325,6 +326,7 @@ class FrookyRunner:
         elif opts.spawn:
             pid = self.device.spawn(opts.spawn)
             session = self.device.attach(pid)
+            self.spawned_pid = pid
             return session
 
         else:
@@ -387,8 +389,7 @@ class FrookyRunner:
 
             # Resume if spawned
             if self.options.spawn:
-                pid = self.session.pid
-                self.device.resume(pid)
+                self.device.resume(self.spawned_pid)
 
             # Main loop
             while True:


### PR DESCRIPTION
## Summary

Fixes #20 

This PR resolves an AttributeError that occurs when spawning applications with the `-f` flag.

## Problem

When using the `-f` flag to spawn an app, `frooky` crashes with: 'Session' object has no attribute 'pid'

The issue occurs because the code attempted to access `self.session.pid` on line 315, but Frida's `Session` objects don't have a `pid` attribute.

## Solution

This PR makes the following changes:

1. Added `spawned_pid` attribute to store the PID when spawning an application
2. Store PID after spawn from `device.spawn()` in the `spawned_pid` attribute
3. Use stored PID for resume instead of the non-existent `self.session.pid`

## Testing

After this fix, the command works correctly: 

```sh
frooky -U -f org.owasp.mastestapp --platform android hooks.json
```