### PR TITLE
Add version display to FrookyRunner banner

### DIFF
--- a/frooky/frida_runner.py
+++ b/frooky/frida_runner.py
@@ -12,6 +12,7 @@ from importlib import resources
 from pathlib import Path
 from typing import Optional
 
+from ._version import __version__ as frooky_version
 from .resources import read_text
 
 
@@ -264,7 +265,7 @@ class FrookyRunner:
         
         # Info lines to display on the right
         info = [
-            f"Powered by Frida {frida_version}",
+            f"v{frooky_version} - Powered by Frida {frida_version}",
             f"Target: {self._get_target_description()}",
             "",
             f"Device: {self.device.name}" + (f" ({self.device.id})" if self.device.id else ""),


### PR DESCRIPTION
Include the FrookyRunner version in the banner for better visibility and user awareness.

```sh
% frooky -U -n MASTestApp --platform android docs/examples/hooks*.json

   ___    ____                                v0.1.4.dev35+gecbc98dfe - Powered by Frida 17.6.0
  / __\  / _  |    _     _    _  _   _   _    Target: MASTestApp
 / _\   | (_) |  / _ \ / _ \ | / /  | | | |   
/ /     / / | | | (_) | (_) ||  <   | |_| |   Device: Android Emulator 5554 (emulator-5554)
\/     /_/  |_|  \___/ \___/ |_|\_\  \__, |   Platform: android
                                     |___/    Hook files: 2
                                              Output: output.json

  Press Ctrl+C to stop...
```