### PR TITLE
Minor CLI enhancements

### DIFF
--- a/frooky/cli.py
+++ b/frooky/cli.py
@@ -5,7 +5,6 @@ import argparse
 from pathlib import Path
 from importlib.resources import files
 
-
 from . import __version__
 from .frida_runner import FrookyRunner, RunnerOptions
 
@@ -13,9 +12,10 @@ from .frida_runner import FrookyRunner, RunnerOptions
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="frooky",
-        description="Run Frooky hooks using Frida's Python bindings.",
-        suggest_on_error=True
+        description="Run Frooky hooks using Frida's Python bindings."
     )
+
+    parser.suggest_on_error = True
 
     parser.add_argument(
         "-v",


### PR DESCRIPTION
Minor CLI enhancements

### 1. When empty, fail with help. It's more user friendly

#### Before

<img width="1163" height="88" alt="image" src="https://github.com/user-attachments/assets/380f0543-035a-4d1e-a03e-3b41f84810c4" />

#### After

<img width="1166" height="527" alt="image" src="https://github.com/user-attachments/assets/5d74b45b-72ed-4d14-b6ec-41813a9a67e0" />


### 2. ArgumentParser has suggestions on error 

<img width="1154" height="90" alt="image" src="https://github.com/user-attachments/assets/bffddc7f-361a-47db-afdb-6a2c698bb55b" />


### 3. Add -v shorthand for --version 