### PR TITLE
Fix publishing: Change artifact download path to current directory

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,5 +20,5 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: ${{ needs.build.outputs.artifact-name }}
-          path: dist
+          path: .
       - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
The `gh-action-pypi-publish` action is looking for packages in `dist/dist` instead of just `dist/`. This is because:

1. The artifact is named "dist" (line 21 in publish.yml)
2. When downloaded, it creates a directory with the artifact name
3. We're then setting `path: dist` which downloads the artifact contents into `dist/`
4. But the artifact itself contains a `dist/` directory, resulting in `dist/dist/`

Fix: download to `.` since the `gh-action-pypi-publish` action defaults to looking in `dist/`, and the artifact already contains that structure.