### PR TITLE
Fix publish workflow artifact dependency

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ jobs:
     uses: ./.github/workflows/build.yml
 
   verify-build:
+    needs: [build]
     permissions:
       contents: read
     uses: ./.github/workflows/test-build.yml


### PR DESCRIPTION
## Issue
The `verify-build` job was running in parallel with the `build` job, causing it to fail when trying to download the artifact that hadn't been uploaded yet.

## Fix
Added `needs: [build]` to the `verify-build` job to ensure it waits for the build to complete before attempting to download the artifact.

This ensures the correct execution order:
1. `build` → uploads artifact
2. `verify-build` → downloads and verifies artifact
3. `publish` → publishes to PyPI